### PR TITLE
Fix Memory Overflow if recieved JSON is to big.

### DIFF
--- a/src/RestTask.cpp
+++ b/src/RestTask.cpp
@@ -29,7 +29,7 @@ void RestTask::updateData()
     sprintf(serverPath, "http://%s:%i/api/state", this->servername, this->serverport);
     String jsonBuffer;
     jsonBuffer = httpGETRequest(serverPath);
-    DynamicJsonDocument doc(3500);
+    DynamicJsonDocument doc(6000);
 
     DeserializationError error = deserializeJson(doc, jsonBuffer);
 


### PR DESCRIPTION
Fixed bug https://github.com/powelllens/evcc_eink_monitor/issues/6 if received JSON is to big due to too many load points.
- Increased Memory

Thanks to @sprakelsoft